### PR TITLE
start of round struct

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -1,7 +1,9 @@
 mod game;
 mod player;
 mod hands;
+mod round;
 
 pub use self::game::*;
 pub use self::player::*;
 pub use self::hands::*;
+pub use self::round::*;

--- a/src/game/game.rs
+++ b/src/game/game.rs
@@ -1,5 +1,5 @@
 use super::{Player, Round};
-use crate::cards::{Card, Rank, Suit, Deck, PlayedCard};
+use crate::cards::{Deck, PlayedCard};
 use wasm_bindgen::prelude::*;
 
 // todo - suit order is a property of game
@@ -34,7 +34,7 @@ impl Game {
         Game {
             _num_decks,
             _num_jokers,
-            players: players,
+            players,
             _reversals_enabled,
             round
         }

--- a/src/game/game.rs
+++ b/src/game/game.rs
@@ -1,13 +1,15 @@
-use super::Player;
-use crate::cards::{Deck, PlayedCard};
+use super::{Player, Round};
+use crate::cards::{Card, Rank, Suit, Deck, PlayedCard};
 use wasm_bindgen::prelude::*;
 
+// todo - suit order is a property of game
 #[wasm_bindgen]
 pub struct Game {
     _num_decks: u8,
     _num_jokers: u8,
     players: Vec<Player>,
     _reversals_enabled: bool,
+    round: Round,
 }
 
 impl Game {
@@ -21,17 +23,20 @@ impl Game {
         deck.shuffle();
         let cards = deck.deal(player_ids.len() as u8);
 
-        let players = cards
+        let players:Vec<Player> = cards
             .iter()
             .zip(player_ids)
             .map(|(c, id)| Player::new(id.to_string(), c.clone()))
             .collect();
 
+        let round = Round::new(players.clone(), None);
+
         Game {
             _num_decks,
             _num_jokers,
-            players,
+            players: players,
             _reversals_enabled,
+            round
         }
     }
 
@@ -44,6 +49,10 @@ impl Game {
             Some(p) => Some(p.clone()),
             _ => None,
         }
+    }
+
+    pub fn get_next_player(&self) -> Option<&str> {
+        self.round.get_next_player()
     }
 }
 
@@ -79,6 +88,41 @@ mod tests {
         let player_a = game.get_player("a").unwrap();
 
         assert_eq!(player_a.get_card_count(), 18);
+    }
+
+    #[test]
+    fn when_game_hasnt_started_player_with_3clubs_starts() {
+        let ids = [
+            String::from("a"),
+            String::from("b"),
+        ];
+        let game = Game::new(1, 0, &ids, false);
+
+        let player_a = game.get_player("a").unwrap();
+        let player_b = game.get_player("b").unwrap();
+
+        let a_hand = player_a.get_hand();
+        let b_hand = player_b.get_hand();
+
+        let next_player = game.get_next_player().unwrap();
+        let three_clubs = Card::Standard{
+            rank: Rank::Three,
+            suit: Suit::Clubs,
+        };
+
+        for &card in a_hand.iter() {
+            if card == three_clubs {
+                assert_eq!(next_player, "a");
+                return;
+            } 
+        }
+
+        for &card in b_hand.iter() {
+            if card == three_clubs {
+                assert_eq!(next_player, "b");
+            } 
+        }
+
     }
 
 }

--- a/src/game/round.rs
+++ b/src/game/round.rs
@@ -1,0 +1,85 @@
+use super::Player;
+use crate::cards::{Suit, Rank, Card};
+
+#[derive(Clone, Debug)]
+pub struct Round{
+    pub players: Vec<Player>,
+    pub next_player: Option<&'static str>,
+}
+
+impl Round {
+    pub fn new(
+        players: Vec<Player>,
+        next_player: Option<&'static str>,
+    ) -> Round {
+        Round{
+            players,
+            next_player,
+        }
+    }
+
+    pub fn get_next_player(&self) -> Option<&str> {
+        match self.next_player {
+            None => self.get_starting_player(),
+            x    => x
+        }
+    }
+
+    pub fn get_starting_player(&self) -> Option<&str> {
+        let three_clubs = Card::Standard{
+            suit: Suit::Clubs,
+            rank: Rank::Three,
+        };
+        for player in self.players.iter() {
+            if player.get_hand().contains(&three_clubs) {
+                return Some(player.get_id());
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cards::*;
+
+    #[test]
+    fn when_game_hasnt_started_player_with_3clubs_starts() {
+        let a_cards = vec![
+            Card::Standard{rank: Rank::Three, suit: Suit::Clubs}
+        ];
+        let b_cards = vec![
+            Card::Standard{rank: Rank::Four, suit: Suit::Clubs}
+        ];
+        let player_a = Player::new("a".to_string(), a_cards);
+        let player_b = Player::new("b".to_string(), b_cards);
+
+        let players = vec![player_a, player_b];
+
+        let round = Round::new(players, None);
+
+        assert_eq!(round.get_next_player(), Some("a"));
+    }
+
+
+    #[test]
+    fn when_game_has_started_there_will_be_a_current_player() {
+        let a_cards = vec![
+            Card::Standard{rank: Rank::Three, suit: Suit::Clubs}
+        ];
+        let b_cards = vec![
+            Card::Standard{rank: Rank::Four, suit: Suit::Clubs}
+        ];
+        let player_a = Player::new("a".to_string(), a_cards);
+        let player_b = Player::new("b".to_string(), b_cards);
+
+        let players = vec![player_a, player_b];
+
+        let round = Round::new(players, Some("b"));
+
+        assert_eq!(round.get_next_player(), Some("b"));
+
+    }
+}
+


### PR DESCRIPTION
The idea around the game/round relationship is that the game (totally breaks the SRP) is a container which acts as a general purpose api for the consumer of the library. It also has the responsibility of keeping track of the initial attributes of the game as a whole (ruleset, options, players).

The `Round` is a snapshot of the current state of the game. There are some ownership issues (which I have short term deferred thinking about by blindly cloning) and some parts of `Game` may do better split out, but that's the rationale behind this PR.